### PR TITLE
fix: types not generated in dist directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - 8
 
 before_install:
-  - travis_retry yarn add --peer react react-native react-native-svg
+  - travis_retry yarn add react react-native react-native-svg
 
 install:
   - travis_retry yarn
@@ -24,6 +24,8 @@ jobs:
       script:
         - yarn test --coverage
         - yarn build
+        - yarn remove react react-native react-native-svg
+        - yarn add --peer react react-native react-native-svg
       after_success:
         - yarn codecov
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - 8
 
 before_install:
-  - travis_retry yarn add react react-native react-native-svg
+  - travis_retry yarn global add react react-native react-native-svg
 
 install:
   - travis_retry yarn
@@ -21,9 +21,8 @@ jobs:
   include:
     - stage: release
       node_js: lts/*
-      install:
-        - yarn
       script:
+        - yarn test --coverage
         - yarn build
       after_success:
         - yarn codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - 8
 
 before_install:
-  - travis_retry yarn global add react react-native react-native-svg
+  - travis_retry yarn add --peer react react-native react-native-svg
 
 install:
   - travis_retry yarn

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "An Icon Library for React Native",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "outDir": "dist/",
     "typeRoots": ["types", "node_modules/@types"]
   },
+  "include": ["src/"],
   "exclude": [
+    "__test__",
     "node_modules",
     "babel.config.js",
     "storybook/storyLoader.js",


### PR DESCRIPTION
Typescript definition files are not generated directly in the dist directory. But are generated as a sub directory in dist ("dist/src/index.d.ts").

package.json does not have the types specified.

travis.yml build adding peer deps as deps in builds.